### PR TITLE
Remove TC mention from Security + Tweak phrasing

### DIFF
--- a/xl_troubleshooting.md
+++ b/xl_troubleshooting.md
@@ -66,7 +66,7 @@ Here are some additional details about XIVLauncher itself.
 Here are some additional details about Dalamud.
 
 1. Dalamud **is** a code injection framework. By definition, it's going to look and act like a virus-like program. Your antivirus might even consider it harmful or potentially harmful software! You can read more about [whitelisting Dalamud](#q-how-do-i-whitelist-xivlauncher-and-dalamud-so-my-antivirus-leaves-them-alone) elsewhere on the FAQ. __We recommend whitelisting for the best experience, but your computing environment may not require it.__
-2. Dalamud allows you to read game memory and read incoming game packets. Compare this to using ACT or Teamcraft Desktop. 
+2. Dalamud allows you to read game memory and network packets. Compare this to using ACT. 
 3. Dalamud's framework comes with the ability for modifying game memory/hooking into game client memory and functions that plugins can choose to use. We however only provide safe read-only(where it applies) access to game data in the official [Dalamud game data APIs](https://goatcorp.github.io/Dalamud/api/index.html).
 
 #### Plugin Security Specifics


### PR DESCRIPTION
The semantics of the sentence pre-change suggest that both ACT and TC Desktop read game memory and networking packets.
I'm not sure how to word this to clarify that TC Desktop only reads game packets and does not read memory, so I just removed
it from the section altogether. We can add it back if we can rephrase this elegantly enough to convey the difference without
running on too long. I also changed the phrasing of the packets bit to clarify that Dalamud allows you to read all packets, and
not just incoming ones.