### PR TITLE
Update outdated plugins

### DIFF
--- a/dalamud_troubleshooting.md
+++ b/dalamud_troubleshooting.md
@@ -106,12 +106,28 @@ The following plugins are not currently available to install. If you do not see 
 _These plugins are abandoned by their original developer and haven't been adopted. If you're interested in taking over development, please reach out to the developer and let us know on discord._
 
 - [ACT Endcounter](https://github.com/Leftn/FFXIV-ACT-Endcounter)
-- [Hey Dalamud!](https://github.com/goaaats/dalamudvox)
+- [Blue Mage Helper](https://github.com/markjsosnowski/BlueMageHelper)
+- [Chat Emote Color](https://github.com/chrisk699/ffxiv-chatemotecolor-plugin)
+- [Chat Translator](https://github.com/Haplo064/ChatTranslator)
 - [DeviceChangeFix](https://github.com/PGGB/DeviceChangeFix)
+- [Doman Mahjong Status](https://github.com/iamevn/DomanMahjongStatus)
+- [Elden Ring](https://github.com/Roselyyn/EldenRingDalamud)
+- [Fantasy Player](https://github.com/Dormanil/FantasyPlayer)
+- [Hey Dalamud!](https://github.com/goaaats/dalamudvox)
+- [Hide Padlock](https://github.com/Fr4nsson/MyDalamudPlugins/tree/main/src/HidePadlock)
+- [Job Gauge Adjustments](https://github.com/SupineSnail/SupineSnail.JobGaugeAdjustments)
 - [MPTimer](https://github.com/talimity/mptimer)
+- [Mount Collector](https://github.com/Samuelkaa/MountCollectioner)
+- [Mouse Target Tooltip](https://github.com/Arrenton/MouseTargetTooltip)
 - [Ocean Fishin'](https://github.com/markjsosnowski/OceanFishin)
+- [Oh gee, CD](https://github.com/rootdarkarchon/OhGeeCD)
+- [Quote Of The Lobby](https://github.com/Soreepeong/QuoteOfTheLobby)
 - [RemindMe](https://github.com/Caraxi/RemindMe)
+- [Reset Audio](https://github.com/Soreepeong/FFXIV-ResetAudio)
+- [Reset Enmity Command](https://github.com/akira0245/Reset-dummy-enmity-command)
 - [Side HUD](https://github.com/SheepGoMeh/SideHUD)
+- [Simple Compare](https://github.com/Rennerdo30/ffxiv-simplecompare)
+- [Size Matters](https://github.com/joshua-software-dev/SizeMattersFishing)
 - [TabTab](https://github.com/avafloww/TabTab)
 
 #### Discontinued
@@ -126,6 +142,7 @@ _These plugins have been discontinued due to our plugin rules or the developer's
 _These plugins are now obsolete and no longer needed. This can be due to new features added to the game or by being replaced by another plugin. They won't be coming back._
 
 - AccurateCountDown - _Replaced by EngageTimer_
+- BatteryGauge - _Replaced by SimpleTweaks (eventually)_
 - BrowserHost.Plugin - _Replaced by Browsingway_
 - CharSyncPlugin - _Use Character Data Sync_
 - ChatExtender - _Split into Chat Bubbles, Chat Translator, and XIVLogger_


### PR DESCRIPTION
Update outdated plugins ahead of the patch. These are all API 6 and haven't been touched in over 6+ months. SkillDisplay is outdated but I saw recent activity on GitHub so I excluded it for now.