### PR TITLE
Extend update check failure with hard disk full

### DIFF
--- a/xl_troubleshooting.md
+++ b/xl_troubleshooting.md
@@ -401,6 +401,7 @@ If you're sure this isn't a firewall issue or a rate limit, here are some things
 
 - Reboot the computer
 - Reboot the network equipment (modem and router)
+- Ensure your hard disk is not full
 - Try different DNS
   - Google offers 8.8.8.8 and 8.8.4.4
   - CloudFlare offers 1.1.1.1 and 1.0.0.1


### PR DESCRIPTION
I got a "could not download necessary files" message after logging in. After extensively debugging my network's DNS server/adblocks, it turns out that instead my hard disk was almost full and the download had nowhere to go. Add this to the relevant entry in the FAQ.