### PR TITLE
Add LC_CTYPE to the Steam Deck page

### DIFF
--- a/steamdeck.md
+++ b/steamdeck.md
@@ -24,7 +24,7 @@ Open the `Discover Store`, search for `XIVLauncher`, and press Install.
 
 In Steam's Desktop mode, select `ADD A GAME`, scroll down to XIVLauncher, click the checkbox, and click `ADD SELECTED PROGRAM`
 
-Right click on XIVLauncher in Steam, select `Properties`, and replace the `Launch Options` with the following: `XL_SECRET_PROVIDER=FILE %command% run --parent-expose-pids --parent-share-pids --parent-pid=1 --branch=stable --arch=x86_64 --command=xivlauncher dev.goats.xivlauncher`
+Right click on XIVLauncher in Steam, select `Properties`, and replace the `Launch Options` with the following: `XL_SECRET_PROVIDER=FILE LC_CTYPE=C.UTF-8 %command% run --parent-expose-pids --parent-share-pids --parent-pid=1 --branch=stable --arch=x86_64 --command=xivlauncher dev.goats.xivlauncher`
 
 Please note that with this configuration, XIVLauncher will save your password to a file on your Steam Deck, as Valve does not ship a safer way to store passwords by default. If this is a problem for you, please leave out `XL_SECRET_PROVIDER=FILE %command% ` from the line above - XIVLauncher won't be able to save your password in that case.
 


### PR DESCRIPTION
Running the game with `LC_CTYPE` set to a UTF-8 locale fixes that infamous issue with Unicode in file paths.

The `C.UTF-8` locale is suggested because, AFAIK, until the very last Steam Deck system update, it was the only available UTF-8 locale, and therefore seems the safest to use.

Discussed with @reiichi001 on Discord.